### PR TITLE
add Example Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,28 +8,45 @@ Using a semantic versioning system, this module also provides backward compatibi
   <img src="https://darkcrystal.pw/assets/images/darkcrystal-logo.jpg" width="500" alt="dark-crystal-secrets">
 </p>
 
+## Example
+
+```js
+const { pack, unpack. share, verify, combine } = require('dark-crystal-secretes')
+
+const labelledSecret = pack('burried under my tree fort', 'treasure chest 1')
+const shares = share(labelledSecret, 5, 3) // split into 5 parts, quorum 3
+
+shares.forEach(share => console.log(validateShard(share, '2.0.0'))
+
+const validity = verify(share.slice(0,3), '2.0.0')
+console.log(validity)
+
+const recoveredLabelledSecret = combine(share.slice(0,3), '2.0.0')
+const { secret, label } = unpack(recoveredLabelledSecret, '2.0.0')
+```
+
 ## API
 
-#### `darkCrystal.pack(secret, label)`
+#### `pack(secret, label)`
 The `secret` is bundled up with the `label` given to the secret and stringified as `JSON`
 
-#### `darkCrystal.unpack(secret, version)`
+#### `unpack(secret, version)`
 The `secret` is separated from the `label` and returned as an object
 
-#### `darkCrystal.share(secret, numOfShards, quorum)`
+#### `share(secret, numOfShards, quorum)`
 * Generates a `MAC` which is composed the first 32 characters (16 bytes) of a `SHA256` hash of the `secret`
 * Concatenates it at the beginning of the `secret`
 * Splits the secret into `numOfShards`, where `quorum` is the number required to reassemble
 * Compresses the `shards` from `hex` into `base64` for more efficient storage
 
-#### `darkCrystal.verify(shards, version)`
+#### `verify(shards, version)`
 * Decompresses the `shards` from `base64` to `hex`
 * Reassembles the secret
 * Checksig
   * `MAC` generated from the newly returned secret match the `MAC` attached to the returned secret.
   * Returns `false` if fails to pass check
 
-#### `darkCrystal.combine(shards, version)`
+#### `combine(shards, version)`
 * Decompresses the shards from base64 to hex
 * Reassembles the secret
 * Checksig
@@ -37,7 +54,7 @@ The `secret` is separated from the `label` and returned as an object
   * Throws an error if it fails to pass the check
 * Returns the `JSON` string secret
 
-#### `darkCrystal.validateShard(shard, version)`
+#### `validateShard(shard, version)`
 * Decompresses the shards from base64 to hex
 * Extracts components of the shard
   * `bits`: [Number] The number of bits configured when the share was created.


### PR DESCRIPTION
hey @KGibb8 I think this needs an example usage section.

I've not run the code I wrote, but I think seeing if I understood what you wrote and what's missing (e.g. that combine returns `{label, secret}` (more specific that "JSON") could be informative)

Feel free to change/ mutate this, simplify it.

I showed all the functions being used because standalone it's kinda unclear how to plug all these together - as that context was born in `scuttle-dark-crystal`